### PR TITLE
prevent '//' at beginning of return, given a filepath

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ function splitPath(x) {
 }
 
 function join(parts, filename) {
-	return parts.join(path.sep) + path.sep + filename;
+	var base = parts.join(path.sep);
+	return base ? (base + path.sep + filename) : filename;
 }
 
 module.exports = function (filename, opts) {

--- a/test.js
+++ b/test.js
@@ -3,19 +3,33 @@ import path from 'path';
 import fn from './';
 
 const pkgPath = path.resolve('.', 'package.json');
+const bazPath = path.resolve('.', 'fixture', 'baz.js');
+const fixture = path.join('.', 'fixture', 'foo', 'bar');
 
-test('async', async t => {
+test('async (dir)', async t => {
 	const filePath = await fn('package.json', {
-		cwd: path.join('.', 'fixture', 'foo', 'bar')
+		cwd: fixture
 	});
 
 	t.is(filePath, pkgPath);
 });
 
-test('sync', t => {
+test('sync (dir)', t => {
 	const fp = fn.sync('package.json', {
-		cwd: path.join('.', 'fixture', 'foo', 'bar')
+		cwd: fixture
 	});
 
 	t.is(fp, pkgPath);
+});
+
+test('async (file)', async t => {
+	const filePath = await fn(bazPath);
+
+	t.is(filePath, bazPath);
+});
+
+test('sync (file)', t => {
+	const filePath = fn.sync(bazPath);
+
+	t.is(filePath, bazPath);
 });


### PR DESCRIPTION
Even though it's written that a `filename + cwd` should be passed, I reckon this repo should still work if the full file path is passed in.

Example:

```js
const fixtures = path.join(process.cwd(), 'fixtures');
const file = path.join(fixtures, 'file.txt');

findUp('file.txt', {cwd: fixtures}).then(fp => {
  // as expected: /Users/luke...../file.txt
});

findUp(file).then(fp => {
  // expected: /Users/luke.../file.txt
  // actual: //Users/luke..../file.txt
});
```

With this change, _both_ scenarios will work.