### PR TITLE
resolve filename relative to search path

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,8 +8,7 @@ function splitPath(x) {
 }
 
 function join(parts, filename) {
-	var base = parts.join(path.sep);
-	return base ? (base + path.sep + filename) : filename;
+	return path.resolve(parts.join(path.sep) + path.sep, filename);
 }
 
 module.exports = function (filename, opts) {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "ava": "*",
+    "tempdir": "^1.0.0",
     "xo": "*"
   }
 }

--- a/test.js
+++ b/test.js
@@ -1,10 +1,21 @@
 import test from 'ava';
+import fs from 'fs';
 import path from 'path';
+import tempdir from 'tempdir';
 import fn from './';
 
 const pkgPath = path.resolve('.', 'package.json');
 const bazPath = path.resolve('.', 'fixture', 'baz.js');
 const fixture = path.join('.', 'fixture', 'foo', 'bar');
+
+// Create a disjoint directory, used for the not-found tests.
+test.beforeEach(async t => {
+	t.context.disjoint = await tempdir();
+});
+
+test.afterEach(t => {
+	fs.rmdirSync(t.context.disjoint);
+});
 
 test('async (dir)', async t => {
 	const filePath = await fn('package.json', {
@@ -32,4 +43,22 @@ test('sync (file)', t => {
 	const filePath = fn.sync(bazPath);
 
 	t.is(filePath, bazPath);
+});
+
+// Both tests start in a disjoint directory. `package.json` should not be found
+// and `null` should be returned.
+test('async (not found)', async t => {
+	const fp = await fn('package.json', {
+		cwd: t.context.disjoint
+	});
+
+	t.is(fp, null);
+});
+
+test('sync (not found)', t => {
+	const fp = fn.sync('package.json', {
+		cwd: t.context.disjoint
+	});
+
+	t.is(fp, null);
 });


### PR DESCRIPTION
PR #3 changes how the filepath is composed. Unfortunately if the filename is not found in the root it searches for the filename itself, relative to the current working directory.

When using find-up to find a file in a disjoint directory, where that file also exists in the current working directory (say a `package.json` file), the local file is returned.

This commit adds tests for find-up returning `null` if a file is not found, and ensures the filename is resolved relative to the root and not the working directory.