### PR TITLE
Add `findUpMultiple`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -116,6 +116,106 @@ console.log(findUpSync(directory => {
 export function findUpSync(matcher: (directory: string) => Match, options?: Options): string | undefined;
 
 /**
+Find files or directories by walking up parent directories.
+
+@param name - The name of the file or directory to find. Can be multiple.
+@returns All paths found (by respecting the order of `name`s) or `undefined` if none could be found.
+
+@example
+```
+// /
+// └── Users
+//     └── sindresorhus
+//         ├── unicorn.png
+//         └── foo
+//             ├── unicorn.png
+//             └── bar
+//                 ├── baz
+//                 └── example.js
+
+// example.js
+import {findUpMultiple} from 'find-up';
+
+console.log(await findUpMultiple('unicorn.png'));
+//=> ['/Users/sindresorhus/foo/unicorn.png', '/Users/sindresorhus/unicorn.png']
+
+console.log(await findUpMultiple(['rainbow.png', 'unicorn.png']));
+//=> ['/Users/sindresorhus/foo/unicorn.png', '/Users/sindresorhus/unicorn.png']
+```
+*/
+export function findUpMultiple(name: string | readonly string[], options?: Options): Promise<string[] | undefined>;
+
+/**
+Find files or directories by walking up parent directories.
+
+@param matcher - Called for each directory in the search. Return a path or `findUpStop` to stop the search.
+@returns All paths found or `undefined` if none could be found.
+
+@example
+```
+import path from 'node:path';
+import {findUpMultiple, pathExists} from 'find-up';
+
+console.log(await findUpMultiple(async directory => {
+  const hasUnicorns = await pathExists(path.join(directory, 'unicorn.png'));
+  return hasUnicorns && directory;
+}, {type: 'directory'}));
+//=> ['/Users/sindresorhus/foo', '/Users/sindresorhus']
+```
+*/
+export function findUpMultiple(matcher: (directory: string) => (Match | Promise<Match>), options?: Options): Promise<string[] | undefined>;
+
+/**
+Synchronously find files or directories by walking up parent directories.
+
+@param name - The name of the file or directory to find. Can be multiple.
+@returns All paths found (by respecting the order of `name`s) or `undefined` if none could be found.
+
+@example
+```
+// /
+// └── Users
+//     └── sindresorhus
+//         ├── unicorn.png
+//         └── foo
+//             ├── unicorn.png
+//             └── bar
+//                 ├── baz
+//                 └── example.js
+
+// example.js
+import {findUpMultipleSync} from 'find-up';
+
+console.log(findUpMultipleSync('unicorn.png'));
+//=> ['/Users/sindresorhus/foo/unicorn.png', '/Users/sindresorhus/unicorn.png']
+
+console.log(findUpMultipleSync(['rainbow.png', 'unicorn.png']));
+//=> ['/Users/sindresorhus/foo/unicorn.png', '/Users/sindresorhus/unicorn.png']
+```
+*/
+export function findUpMultipleSync(name: string | readonly string[], options?: Options): string[] | undefined;
+
+/**
+Synchronously find files or directories by walking up parent directories.
+
+@param matcher - Called for each directory in the search. Return a path or `findUpStop` to stop the search.
+@returns All paths found or `undefined` if none could be found.
+
+@example
+```
+import path from 'node:path';
+import {findUpMultipleSync, pathExistsSync} from 'find-up';
+
+console.log(findUpMultipleSync(directory => {
+  const hasUnicorns = pathExistsSync(path.join(directory, 'unicorn.png'));
+  return hasUnicorns && directory;
+}, {type: 'directory'}));
+//=> ['/Users/sindresorhus/foo', '/Users/sindresorhus']
+```
+*/
+export function findUpMultipleSync(matcher: (directory: string) => Match, options?: Options): string[] | undefined;
+
+/**
 Check if a path exists.
 
 @param path - The path to a file or directory.

--- a/index.js
+++ b/index.js
@@ -43,6 +43,49 @@ export async function findUp(name, options = {}) {
 	}
 }
 
+export async function findUpMultiple(name, options = {}) {
+	let directory = path.resolve(options.cwd || '');
+	const {root} = path.parse(directory);
+	const stopAt = path.resolve(directory, options.stopAt || root);
+	const paths = [name].flat();
+
+	const runMatcher = async locateOptions => {
+		if (typeof name !== 'function') {
+			return locatePath(paths, locateOptions);
+		}
+
+		const foundPath = await name(locateOptions.cwd);
+		if (typeof foundPath === 'string') {
+			return locatePath([foundPath], locateOptions);
+		}
+
+		return foundPath;
+	};
+
+	const matches = [];
+	// eslint-disable-next-line no-constant-condition
+	while (true) {
+		// eslint-disable-next-line no-await-in-loop
+		const foundPath = await runMatcher({...options, cwd: directory});
+
+		if (foundPath === findUpStop) {
+			break;
+		}
+
+		if (foundPath) {
+			matches.push(path.resolve(directory, foundPath));
+		}
+
+		if (directory === stopAt) {
+			break;
+		}
+
+		directory = path.dirname(directory);
+	}
+
+	return matches.length > 0 ? matches : undefined;
+}
+
 export function findUpSync(name, options = {}) {
 	let directory = path.resolve(options.cwd || '');
 	const {root} = path.parse(directory);
@@ -80,6 +123,48 @@ export function findUpSync(name, options = {}) {
 
 		directory = path.dirname(directory);
 	}
+}
+
+export function findUpMultipleSync(name, options = {}) {
+	let directory = path.resolve(options.cwd || '');
+	const {root} = path.parse(directory);
+	const stopAt = options.stopAt || root;
+	const paths = [name].flat();
+
+	const runMatcher = locateOptions => {
+		if (typeof name !== 'function') {
+			return locatePathSync(paths, locateOptions);
+		}
+
+		const foundPath = name(locateOptions.cwd);
+		if (typeof foundPath === 'string') {
+			return locatePathSync([foundPath], locateOptions);
+		}
+
+		return foundPath;
+	};
+
+	const matches = [];
+	// eslint-disable-next-line no-constant-condition
+	while (true) {
+		const foundPath = runMatcher({...options, cwd: directory});
+
+		if (foundPath === findUpStop) {
+			break;
+		}
+
+		if (foundPath) {
+			matches.push(path.resolve(directory, foundPath));
+		}
+
+		if (directory === stopAt) {
+			break;
+		}
+
+		directory = path.dirname(directory);
+	}
+
+	return matches.length > 0 ? matches : undefined;
 }
 
 export {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
 import {expectType, expectError} from 'tsd';
-import {findUp, findUpSync, findUpStop, pathExists, pathExistsSync} from './index.js';
+import {findUp, findUpSync, findUpMultiple, findUpMultipleSync, findUpStop, pathExists, pathExistsSync} from './index.js';
 
 expectType<Promise<string | undefined>>(findUp('unicorn.png'));
 expectType<Promise<string | undefined>>(findUp('unicorn.png', {cwd: ''}));
@@ -52,6 +52,57 @@ expectType<Promise<string | undefined>>(findUp(async (): Promise<typeof findUpSt
 expectType<Promise<string | undefined>>(findUp(async (): Promise<typeof findUpStop> => findUpStop, {type: 'directory'}));
 expectType<Promise<string | undefined>>(findUp(async (): Promise<typeof findUpStop> => findUpStop, {stopAt: 'foo'}));
 
+expectType<Promise<string[] | undefined>>(findUpMultiple('unicorn.png'));
+expectType<Promise<string[] | undefined>>(findUpMultiple('unicorn.png', {cwd: ''}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(['rainbow.png', 'unicorn.png']));
+expectType<Promise<string[] | undefined>>(findUpMultiple(['rainbow.png', 'unicorn.png'], {cwd: ''}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(['rainbow.png', 'unicorn.png'], {allowSymlinks: true}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(['rainbow.png', 'unicorn.png'], {allowSymlinks: false}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(['rainbow.png', 'unicorn.png'], {type: 'file'}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(['rainbow.png', 'unicorn.png'], {type: 'directory'}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(['rainbow.png', 'unicorn.png'], {stopAt: 'foo'}));
+expectError(findUpMultiple(['rainbow.png', 'unicorn.png'], {concurrency: 1}));
+
+expectType<Promise<string[] | undefined>>(findUpMultiple(() => 'unicorn.png'));
+expectType<Promise<string[] | undefined>>(findUpMultiple(() => 'unicorn.png', {cwd: ''}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(() => 'unicorn.png', {allowSymlinks: true}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(() => 'unicorn.png', {allowSymlinks: false}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(() => 'unicorn.png', {type: 'file'}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(() => 'unicorn.png', {type: 'directory'}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(() => 'unicorn.png', {stopAt: 'foo'}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(() => undefined));
+expectType<Promise<string[] | undefined>>(findUpMultiple(() => undefined, {cwd: ''}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(() => undefined, {allowSymlinks: true}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(() => undefined, {allowSymlinks: false}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(() => undefined, {type: 'file'}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(() => undefined, {type: 'directory'}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(() => undefined, {stopAt: 'foo'}));
+expectType<Promise<string[] | undefined>>(findUpMultiple((): typeof findUpStop => findUpStop));
+expectType<Promise<string[] | undefined>>(findUpMultiple((): typeof findUpStop => findUpStop, {cwd: ''}));
+expectType<Promise<string[] | undefined>>(findUpMultiple((): typeof findUpStop => findUpStop, {stopAt: 'foo'}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(async () => 'unicorn.png'));
+expectType<Promise<string[] | undefined>>(findUpMultiple(async () => 'unicorn.png', {cwd: ''}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(async () => 'unicorn.png', {allowSymlinks: true}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(async () => 'unicorn.png', {allowSymlinks: false}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(async () => 'unicorn.png', {type: 'file'}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(async () => 'unicorn.png', {type: 'directory'}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(async () => 'unicorn.png', {stopAt: 'foo'}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(async () => undefined));
+expectType<Promise<string[] | undefined>>(findUpMultiple(async () => undefined, {cwd: ''}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(async () => undefined, {allowSymlinks: true}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(async () => undefined, {allowSymlinks: false}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(async () => undefined, {type: 'file'}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(async () => undefined, {type: 'directory'}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(async () => undefined, {stopAt: 'foo'}));
+
+expectType<Promise<string[] | undefined>>(findUpMultiple(async (): Promise<typeof findUpStop> => findUpStop));
+expectType<Promise<string[] | undefined>>(findUpMultiple(async (): Promise<typeof findUpStop> => findUpStop, {cwd: ''}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(async (): Promise<typeof findUpStop> => findUpStop, {allowSymlinks: true}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(async (): Promise<typeof findUpStop> => findUpStop, {allowSymlinks: false}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(async (): Promise<typeof findUpStop> => findUpStop, {type: 'file'}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(async (): Promise<typeof findUpStop> => findUpStop, {type: 'directory'}));
+expectType<Promise<string[] | undefined>>(findUpMultiple(async (): Promise<typeof findUpStop> => findUpStop, {stopAt: 'foo'}));
+
 expectType<string | undefined>(findUpSync('unicorn.png'));
 expectType<string | undefined>(findUpSync('unicorn.png', {cwd: ''}));
 expectType<string | undefined>(findUpSync(['rainbow.png', 'unicorn.png']));
@@ -81,6 +132,35 @@ expectType<string | undefined>(findUpSync((): typeof findUpStop => findUpStop, {
 expectType<string | undefined>(findUpSync((): typeof findUpStop => findUpStop, {type: 'file'}));
 expectType<string | undefined>(findUpSync((): typeof findUpStop => findUpStop, {type: 'directory'}));
 expectType<string | undefined>(findUpSync((): typeof findUpStop => findUpStop, {stopAt: 'foo'}));
+
+expectType<string[] | undefined>(findUpMultipleSync('unicorn.png'));
+expectType<string[] | undefined>(findUpMultipleSync('unicorn.png', {cwd: ''}));
+expectType<string[] | undefined>(findUpMultipleSync(['rainbow.png', 'unicorn.png']));
+expectType<string[] | undefined>(findUpMultipleSync(['rainbow.png', 'unicorn.png'], {cwd: ''}));
+expectType<string[] | undefined>(findUpMultipleSync(['rainbow.png', 'unicorn.png'], {allowSymlinks: true}));
+expectType<string[] | undefined>(findUpMultipleSync(['rainbow.png', 'unicorn.png'], {allowSymlinks: false}));
+expectType<string[] | undefined>(findUpMultipleSync(['rainbow.png', 'unicorn.png'], {type: 'file'}));
+expectType<string[] | undefined>(findUpMultipleSync(['rainbow.png', 'unicorn.png'], {type: 'directory'}));
+expectType<string[] | undefined>(findUpMultipleSync(['rainbow.png', 'unicorn.png'], {stopAt: 'foo'}));
+expectType<string[] | undefined>(findUpMultipleSync(() => 'unicorn.png'));
+expectType<string[] | undefined>(findUpMultipleSync(() => 'unicorn.png', {cwd: ''}));
+expectType<string[] | undefined>(findUpMultipleSync(() => 'unicorn.png', {allowSymlinks: true}));
+expectType<string[] | undefined>(findUpMultipleSync(() => 'unicorn.png', {allowSymlinks: false}));
+expectType<string[] | undefined>(findUpMultipleSync(() => 'unicorn.png', {type: 'file'}));
+expectType<string[] | undefined>(findUpMultipleSync(() => 'unicorn.png', {type: 'directory'}));
+expectType<string[] | undefined>(findUpMultipleSync(() => 'unicorn.png', {stopAt: 'foo'}));
+expectType<string[] | undefined>(findUpMultipleSync(() => undefined));
+expectType<string[] | undefined>(findUpMultipleSync(() => undefined, {cwd: ''}));
+expectType<string[] | undefined>(findUpMultipleSync(() => undefined, {allowSymlinks: true}));
+expectType<string[] | undefined>(findUpMultipleSync(() => undefined, {allowSymlinks: false}));
+expectType<string[] | undefined>(findUpMultipleSync(() => undefined, {type: 'file'}));
+expectType<string[] | undefined>(findUpMultipleSync(() => undefined, {type: 'directory'}));
+expectType<string[] | undefined>(findUpMultipleSync(() => undefined, {stopAt: 'foo'}));
+expectType<string[] | undefined>(findUpMultipleSync((): typeof findUpStop => findUpStop));
+expectType<string[] | undefined>(findUpMultipleSync((): typeof findUpStop => findUpStop, {cwd: ''}));
+expectType<string[] | undefined>(findUpMultipleSync((): typeof findUpStop => findUpStop, {type: 'file'}));
+expectType<string[] | undefined>(findUpMultipleSync((): typeof findUpStop => findUpStop, {type: 'directory'}));
+expectType<string[] | undefined>(findUpMultipleSync((): typeof findUpStop => findUpStop, {stopAt: 'foo'}));
 
 expectType<Promise<boolean>>(pathExists('unicorn.png'));
 expectType<boolean>(pathExistsSync('unicorn.png'));

--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,15 @@ Returns a `Promise` for either the path or `undefined` if it couldn't be found.
 
 Returns a `Promise` for either the first path found (by respecting the order of the array) or `undefined` if none could be found.
 
+### findUpMultiple(name, options?)
+### findUpMultiple(matcher, options?)
+
+Returns a `Promise` for either the array of paths or `undefined` if it couldn't be found.
+
+### findUpMultiple([...name], options?)
+
+Returns a `Promise` for either an array of the first paths found (by respecting the order of the array) or `undefined` if none could be found.
+
 ### findUpSync(name, options?)
 ### findUpSync(matcher, options?)
 
@@ -59,6 +68,15 @@ Returns a path or `undefined` if it couldn't be found.
 ### findUpSync([...name], options?)
 
 Returns the first path found (by respecting the order of the array) or `undefined` if none could be found.
+
+### findUpMultipleSync(name, options?)
+### findUpMultipleSync(matcher, options?)
+
+Returns an array of paths or `undefined` if it couldn't be found.
+
+### findUpMultipleSync([...name], options?)
+
+Returns an array of the first paths found (by respecting the order of the array) or `undefined` if none could be found.
 
 #### name
 

--- a/test.js
+++ b/test.js
@@ -14,6 +14,8 @@ const name = {
 	packageDirectory: 'find-up',
 	packageJson: 'package.json',
 	fixtureDirectory: 'fixture',
+	fooDirectory: 'foo',
+	barDirectory: 'bar',
 	modulesDirectory: 'node_modules',
 	baz: 'baz.js',
 	qux: 'qux.js',
@@ -28,8 +30,8 @@ const relative = {
 };
 relative.baz = path.join(relative.fixtureDirectory, name.baz);
 relative.qux = path.join(relative.fixtureDirectory, name.qux);
-relative.barDirQux = path.join(relative.fixtureDirectory, 'foo', 'bar', name.qux);
-relative.barDir = path.join(relative.fixtureDirectory, 'foo', 'bar');
+relative.barDirQux = path.join(relative.fixtureDirectory, name.fooDirectory, name.barDirectory, name.qux);
+relative.barDir = path.join(relative.fixtureDirectory, name.fooDirectory, name.barDirectory);
 
 const absolute = {
 	packageDirectory: __dirname,
@@ -41,9 +43,9 @@ absolute.fixtureDirectory = path.join(
 );
 absolute.baz = path.join(absolute.fixtureDirectory, name.baz);
 absolute.qux = path.join(absolute.fixtureDirectory, name.qux);
-absolute.fooDir = path.join(absolute.fixtureDirectory, 'foo');
-absolute.barDir = path.join(absolute.fixtureDirectory, 'foo', 'bar');
-absolute.barDirQux = path.join(absolute.fixtureDirectory, 'foo', 'bar', name.qux);
+absolute.fooDir = path.join(absolute.fixtureDirectory, name.fooDirectory);
+absolute.barDir = path.join(absolute.fixtureDirectory, name.fooDirectory, name.barDirectory);
+absolute.barDirQux = path.join(absolute.fixtureDirectory, name.fooDirectory, name.barDirectory, name.qux);
 absolute.fileLink = path.join(absolute.fixtureDirectory, name.fileLink);
 absolute.directoryLink = path.join(absolute.fixtureDirectory, name.directoryLink);
 
@@ -351,6 +353,18 @@ test('sync multiple (child file)', t => {
 	t.deepEqual(filePaths, [absolute.barDirQux, absolute.qux]);
 });
 
+test('async multiple (child directory)', async t => {
+	const foundPath = await findUpMultiple(name.fixtureDirectory, {type: 'directory'});
+
+	t.deepEqual(foundPath, [absolute.fixtureDirectory]);
+});
+
+test('sync multiple (child directory)', t => {
+	const foundPath = findUpMultipleSync(name.fixtureDirectory, {type: 'directory'});
+
+	t.deepEqual(foundPath, [absolute.fixtureDirectory]);
+});
+
 test('async multiple (child file, array)', async t => {
 	const filePaths = await findUpMultiple([name.baz, name.qux], {cwd: relative.barDir});
 
@@ -361,6 +375,24 @@ test('sync multiple (child file, array)', t => {
 	const filePaths = findUpMultipleSync([name.baz, name.qux], {cwd: relative.barDir});
 
 	t.deepEqual(filePaths, [absolute.barDirQux, absolute.baz]);
+});
+
+test('async multiple (child directory, custom cwd, array)', async t => {
+	const foundPath = await findUpMultiple([name.fixtureDirectory, name.fooDirectory], {
+		cwd: absolute.barDir,
+		type: 'directory',
+	});
+
+	t.deepEqual(foundPath, [absolute.fooDir, absolute.fixtureDirectory]);
+});
+
+test('sync multiple (child directory, custom cwd, array)', t => {
+	const foundPath = findUpMultipleSync([name.fixtureDirectory, name.fooDirectory], {
+		cwd: absolute.barDir,
+		type: 'directory',
+	});
+
+	t.deepEqual(foundPath, [absolute.fooDir, absolute.fixtureDirectory]);
 });
 
 test('async multiple (child file with stopAt)', async t => {


### PR DESCRIPTION
Fixes #27.

I'm a bit concerned about the amount of duplication in code: looks like `findUp` could be a decorated version of `findUpMultiple`. On the other hand, duplication is cheaper than wrong abstraction. What do you think?

P. S. PR looks huge. Let me know if that's a problem, I'll split it in multiple smaller PRs.