### PR TITLE
update/tempy

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 	"devDependencies": {
 		"ava": "^3.15.0",
 		"is-path-inside": "^4.0.0",
-		"tempy": "^2.0.0",
+		"tempy": "^3.0.0",
 		"tsd": "^0.17.0",
 		"xo": "^0.44.0"
 	}

--- a/test.js
+++ b/test.js
@@ -5,7 +5,7 @@ import path from 'node:path';
 import {fileURLToPath, pathToFileURL} from 'node:url';
 import test from 'ava';
 import isPathInside from 'is-path-inside';
-import tempy from 'tempy';
+import {temporaryDirectory} from 'tempy';
 import {findUp, findUpSync, findUpMultiple, findUpMultipleSync, findUpStop, pathExists, pathExistsSync} from './index.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -55,8 +55,8 @@ const url = {
 
 // Create a disjoint directory, used for the not-found tests
 test.beforeEach(t => {
-	const temporaryDirectory = tempy.directory();
-	t.context.disjoint = temporaryDirectory;
+	const disjointDirectory = temporaryDirectory();
+	t.context.disjoint = disjointDirectory;
 });
 
 test.afterEach(t => {

--- a/test.js
+++ b/test.js
@@ -55,8 +55,7 @@ const url = {
 
 // Create a disjoint directory, used for the not-found tests
 test.beforeEach(t => {
-	const disjointDirectory = temporaryDirectory();
-	t.context.disjoint = disjointDirectory;
+	t.context.disjoint = temporaryDirectory();
 });
 
 test.afterEach(t => {


### PR DESCRIPTION
- Updating `tempy` to ^3.0.0
- Updating to use named imports for `tempy`, based on guidance [here](https://github.com/sindresorhus/tempy/releases/tag/v3.0.0)