### PR TITLE
Stop re-exporting path-exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,8 +100,3 @@ export function findUpSync(name, options = {}) {
 	const matches = findUpMultipleSync(name, {...options, limit: 1});
 	return matches[0];
 }
-
-export {
-	pathExists,
-	pathExistsSync,
-} from 'path-exists';

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
 	],
 	"dependencies": {
 		"locate-path": "^7.2.0",
-		"path-exists": "^5.0.0",
 		"unicorn-magic": "^0.1.0"
 	},
 	"devDependencies": {

--- a/test.js
+++ b/test.js
@@ -12,8 +12,6 @@ import {
 	findUpMultiple,
 	findUpMultipleSync,
 	findUpStop,
-	pathExists,
-	pathExistsSync,
 } from './index.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -565,28 +563,6 @@ test('sync (matcher function stops early)', t => {
 	}), undefined);
 	t.true(visited.has(cwd));
 	t.is(visited.size, 1);
-});
-
-test('async (check if path exists)', async t => {
-	if (!isWindows) {
-		t.true(await pathExists(absolute.directoryLink));
-		t.true(await pathExists(absolute.fileLink));
-	}
-
-	t.true(await pathExists(absolute.barDir));
-	t.true(await pathExists(absolute.packageJson));
-	t.false(await pathExists('fake'));
-});
-
-test('sync (check if path exists)', t => {
-	if (!isWindows) {
-		t.true(pathExistsSync(absolute.directoryLink));
-		t.true(pathExistsSync(absolute.fileLink));
-	}
-
-	t.true(pathExistsSync(absolute.barDir));
-	t.true(pathExistsSync(absolute.packageJson));
-	t.false(pathExistsSync('fake'));
 });
 
 test('async multiple (child file)', async t => {


### PR DESCRIPTION
This would be a breaking change, but is a suggestion I wanted to make for the next major version. Most consumers of this package won't need to call `pathExists`. E.g. I saw `eslint` using this package without checking if paths exist: https://github.com/eslint/eslint/blob/9e6d6405c3ee774c2e716a3453ede9696ced1be7/lib/eslint/eslint.js#L15

Additionally, `pathExistsSync` is available in Node.js as `fs.existsSync` and `fs.stat`/`fs.access` can often be used in place of `pathExists`