### PR TITLE
Replace sync and async to quansync

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,77 +1,42 @@
 import path from 'node:path';
 import {locatePath, locatePathSync} from 'locate-path';
 import {toPath} from 'unicorn-magic';
+import {quansync} from 'quansync';
 
 export const findUpStop = Symbol('findUpStop');
 
-export async function findUpMultiple(name, options = {}) {
-	let directory = path.resolve(toPath(options.cwd) ?? '');
-	const {root} = path.parse(directory);
-	const stopAt = path.resolve(directory, toPath(options.stopAt ?? root));
-	const limit = options.limit ?? Number.POSITIVE_INFINITY;
-	const paths = [name].flat();
+const locatePathQuansync = quansync({
+	sync: (paths, options) => locatePathSync(paths, options),
+	async: (paths, options) => locatePath(paths, options),
+});
 
-	const runMatcher = async locateOptions => {
-		if (typeof name !== 'function') {
-			return locatePath(paths, locateOptions);
-		}
-
-		const foundPath = await name(locateOptions.cwd);
-		if (typeof foundPath === 'string') {
-			return locatePath([foundPath], locateOptions);
-		}
-
-		return foundPath;
-	};
-
-	const matches = [];
-	// eslint-disable-next-line no-constant-condition
-	while (true) {
-		// eslint-disable-next-line no-await-in-loop
-		const foundPath = await runMatcher({...options, cwd: directory});
-
-		if (foundPath === findUpStop) {
-			break;
-		}
-
-		if (foundPath) {
-			matches.push(path.resolve(directory, foundPath));
-		}
-
-		if (directory === stopAt || matches.length >= limit) {
-			break;
-		}
-
-		directory = path.dirname(directory);
-	}
-
-	return matches;
-}
-
-export function findUpMultipleSync(name, options = {}) {
+const findUpQuansync = quansync(function * (name, options = {}) {
 	let directory = path.resolve(toPath(options.cwd) ?? '');
 	const {root} = path.parse(directory);
 	const stopAt = path.resolve(directory, toPath(options.stopAt) ?? root);
 	const limit = options.limit ?? Number.POSITIVE_INFINITY;
 	const paths = [name].flat();
 
-	const runMatcher = locateOptions => {
+	const runMatcher = function * (locateOptions) {
 		if (typeof name !== 'function') {
-			return locatePathSync(paths, locateOptions);
+			return yield * locatePathQuansync(paths, locateOptions);
 		}
 
-		const foundPath = name(locateOptions.cwd);
+		const foundPathQuansync = quansync({
+			sync: cwd => name(cwd),
+			async: cwd => name(cwd),
+		});
+		const foundPath = yield * foundPathQuansync(locateOptions.cwd);
 		if (typeof foundPath === 'string') {
-			return locatePathSync([foundPath], locateOptions);
+			return yield * locatePathQuansync([foundPath], locateOptions);
 		}
 
 		return foundPath;
 	};
 
 	const matches = [];
-	// eslint-disable-next-line no-constant-condition
 	while (true) {
-		const foundPath = runMatcher({...options, cwd: directory});
+		const foundPath = yield * runMatcher({...options, cwd: directory});
 
 		if (foundPath === findUpStop) {
 			break;
@@ -89,15 +54,25 @@ export function findUpMultipleSync(name, options = {}) {
 	}
 
 	return matches;
+});
+
+export async function findUpMultiple(name, options = {}) {
+	const matches = await findUpQuansync(name, options);
+	return matches;
+}
+
+export function findUpMultipleSync(name, options = {}) {
+	const matches = findUpQuansync.sync(name, options);
+	return matches;
 }
 
 export async function findUp(name, options = {}) {
-	const matches = await findUpMultiple(name, {...options, limit: 1});
+	const matches = await findUpQuansync(name, {...options, limit: 1});
 	return matches[0];
 }
 
 export function findUpSync(name, options = {}) {
-	const matches = findUpMultipleSync(name, {...options, limit: 1});
+	const matches = findUpQuansync.sync(name, {...options, limit: 1});
 	return matches[0];
 }
 

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 	"dependencies": {
 		"locate-path": "^7.2.0",
 		"path-exists": "^5.0.0",
+		"quansync": "^0.2.8",
 		"unicorn-magic": "^0.1.0"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Using [quansync](https://github.com/quansync-dev/quansync) to replace redundant logic in synchronous and asynchronous internal implementations. The goal is to make the codebase more concise and maintainable without requiring separate sync and async versions while ensuring no changes to external usage behavior.

For more details, refer to: https://antfu.me/posts/async-sync-in-between.